### PR TITLE
Heads up that task.delay() returns None, not AsyncResult.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Celery's [user guide][1]. Send tasks from signal handlers without fear!
             print_model.delay(model_pk)
             transaction.commit()
 
+## Caveats
+
+Due to the task being sent after the current transaction has been commited, the
+`PostTransactionTask` provided in this package does not return an
+`celery.result.AsyncResult` as the original celery `Task` does.
+
+Thus, `print_model.delay(model_pk)` simply returns `None`. In order to track
+the task later on, the `task_id` can be predefined in the `apply_async` method:
+
+        from celery.utils import uuid
+
+        u = uuid()
+        print_model.apply_async((model_pk), {}, task_id=u)
+
 ## Run test suite
 
         $ python setup.py test


### PR DESCRIPTION
The original `Task` from celery returns an `AsyncResult` for `task.delay()` and `task.apply_async(args, kwargs)`.
I think it should be mentioned that this package exhibits a different behavior (due to technical limitations) and how to work around this in order to track tasks later on.
